### PR TITLE
Fixed wrong prospector argument usage

### DIFF
--- a/lib/linter-prospector.js
+++ b/lib/linter-prospector.js
@@ -87,7 +87,7 @@ export default {
           '--output-format=json',
         ];
         if (this.profile !== '') {
-          args.push(`--profile-path=${fixPathString(this.profile, fileDir, projectDir)}`);
+          args.push(`--profile ${fixPathString(this.profile, fileDir, projectDir)}`);
         }
         if (this.userArgs !== '') {
           this.userArgs.split(' ').forEach((arg) => {


### PR DESCRIPTION
To specify the .prospector.yaml file, the commandline argument should be --profile instead of --profile-path